### PR TITLE
Use unmock-server CLI from npm.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,16 @@ FROM node:dubnium
 
 WORKDIR /app
 
-# Checkout and build unmock-server
-RUN git clone --single-branch --branch dev https://github.com/unmock/unmock-js.git
-RUN cd unmock-js && npm i && npm run compile
+RUN npm install -g unmock-server
 
 # Prepare folders where to read services
 RUN mkdir -p __unmock__
 
+# Proxy port and two mock server ports
 EXPOSE 8000 8008 8443
 
-CMD DEBUG=* node unmock-js/packages/unmock-server/index.js
+# Enable DEBUG logs
+ENV DEBUG=*
+
+ENTRYPOINT [ "unmock-server" ]
+CMD [ "start" ]


### PR DESCRIPTION
- `unmock-server start` used as default command
- Also adds `unmock-server` as `ENTRYPOINT`
